### PR TITLE
feat: Test implementation of in-Browser bundling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@types/node": "^16.18.89",
         "@types/react": "^18.2.65",
         "@types/react-dom": "^18.2.22",
+        "esbuild-wasm": "0.8.27",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-scripts": "5.0.1",
@@ -7252,6 +7253,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild-wasm": {
+      "version": "0.8.27",
+      "resolved": "https://registry.npmjs.org/esbuild-wasm/-/esbuild-wasm-0.8.27.tgz",
+      "integrity": "sha512-gwUPDOwWgyD7i9r7LQTpQCKl0dCy4vpKS90YB+LwNW9FBWejrGffL0DF6rwXkY4Sfx2xQ+pth9YFZ2HpNeYFFA==",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/escalade": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@types/node": "^16.18.89",
     "@types/react": "^18.2.65",
     "@types/react-dom": "^18.2.22",
+    "esbuild-wasm": "0.8.27",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,0 +1,53 @@
+import * as esbuild from 'esbuild-wasm';
+import ReactDOM from "react-dom";
+import { useEffect, useRef, useState } from "react";
+import { unpkgPathPlugin } from './plugins/unpkgPathPlugin';
+
+const App = () => {
+    const [input, setInput] = useState('');
+    const [code, setCode] = useState('');
+    const ref = useRef<any>();
+
+    const startService = async () => {
+        ref.current = await esbuild.startService({
+            worker: true,
+            wasmURL: '/esbuild.wasm'
+        })
+    }
+
+    useEffect(() => {
+        startService();
+    }, [])
+
+    const onClick = async () => {
+        if(!ref.current) {
+            return;
+        }
+
+        const result = await ref.current.build({
+            entryPoints: ['index.js'],
+            bundle: true,
+            write: false,
+            plugins: [unpkgPathPlugin()],
+        })
+
+        // console.log(result)
+
+        setCode(result.outputFiles[0].text)
+    }
+
+    return (
+        <div>
+            <textarea value={input} onChange={e => setInput(e.target.value)}></textarea>
+            <div>
+                <button onClick={onClick}>Submit</button>
+            </div>
+            <pre>{code}</pre>
+        </div>
+    )
+}
+
+ReactDOM.render(
+    <App />,
+    document.querySelector('#root')
+)

--- a/src/plugins/unpkgPathPlugin.ts
+++ b/src/plugins/unpkgPathPlugin.ts
@@ -1,0 +1,27 @@
+import * as esbuild from 'esbuild-wasm';
+
+export const unpkgPathPlugin = () => {
+   return {
+      name: "unpkg-path-plugin",
+      setup(build: esbuild.PluginBuild) {
+         build.onResolve({ filter: /.*/ }, async (args: any) => {
+            console.log('on Resolve', args)
+            return { path: args.path, namespace: 'a' };
+         })
+
+         build.onLoad({ filter: /.*/ }, async (args: any) => {
+            console.log('on Load', args)
+
+            if(args.path === 'index.js') {
+               return {
+                  loader: 'jsx',
+                  contents: `
+                     import message from 'tiny-test-pkg'; 
+                     console.log(message);
+                  `,
+               };
+            }
+         });
+      },
+   };
+};


### PR DESCRIPTION
1. Created a small application to test in-Browser bundling
2. Used esbuild-wasm to perform Transpiling + Bundling
3. Used unpkg to fetch packages from NPM Registry