### PR TITLE
improve: Refactor fetchPlugin

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,7 +16,7 @@ const App = () => {
     const startService = async () => {
         ref.current = await esbuild.startService({
             worker: true,
-            wasmURL: '/esbuild.wasm'
+            wasmURL: 'https://unpkg.com/esbuild-wasm@0.8.27/esbuild.wasm'
         })
     }
 

--- a/src/plugins/fetchpulgin.ts
+++ b/src/plugins/fetchpulgin.ts
@@ -10,36 +10,49 @@ export const fetchPlugin = (input: string) => {
    return {
       name: 'fetch-plugn',
       setup(build: esbuild.PluginBuild) {
+         build.onLoad({ filter: /(^index\.js$)/ }, () => {
+            return {
+               loader: 'jsx',
+               contents: input,
+            };
+         })
+
          build.onLoad({ filter: /.*/ }, async (args: any) => {
-            if (args.path === 'index.js') {
-               return {
-                  loader: 'jsx',
-                  contents: input,
-               };
+            const cachedResult = await fileCache.getItem<esbuild.OnLoadResult>(args.path)
+
+            if (cachedResult) {
+               return cachedResult;
             }
+         })
 
-            // const cachedResult = await fileCache.getItem<esbuild.OnLoadResult>(args.path)
-
-            // if (cachedResult) {
-            //    return cachedResult;
-            // }
-
+         build.onLoad({ filter: /.css$/ }, async (args: any) => {
             const { data, request } = await axios.get(args.path);
 
-            const fileType = args.path.match(/.css$/) ? 'css' : 'jsx';
-
             const escaped = data.replace(/\n/g, '').replace(/"/g, '\\"').replace(/'/g, "\\'")
-            const contents = fileType === 'css' ?
+            const contents =
                `
                   const style = document.createElement('style');
                   style.innerText = '${escaped}';
                   document.head.appendChild(style);
-               `
-               : data;
+               `;
 
             const result: esbuild.OnLoadResult = {
                loader: 'jsx',
                contents,
+               resolveDir: new URL('./', request.responseURL).pathname
+            }
+
+            await fileCache.setItem(args.path, result);
+
+            return result;
+         })
+
+         build.onLoad({ filter: /.*/ }, async (args: any) => {
+            const { data, request } = await axios.get(args.path);
+
+            const result: esbuild.OnLoadResult = {
+               loader: 'jsx',
+               contents: data,
                resolveDir: new URL('./', request.responseURL).pathname
             }
 


### PR DESCRIPTION
1. Create separate 'onLoad' for different cases 
2. Extract common caching
3.  Download esbuild.wasm instead of using it from the public directory